### PR TITLE
switched build command to an interactive session

### DIFF
--- a/articles.txt
+++ b/articles.txt
@@ -1,0 +1,7 @@
+https://wiki.freebsd.org/VladimirKrstulja/Guides/Jails
+
+http://ftp.freebsd.org/pub/FreeBSD/releases/amd64/13.4-RELEASE/
+
+https://www.ohreally.nl/2021/02/08/freebsd-jails-a-complete-example/
+
+https://clinta.github.io/freebsd-jails-the-hard-way/

--- a/include/domain/containers/log_command.h
+++ b/include/domain/containers/log_command.h
@@ -13,9 +13,9 @@ using namespace core::operations;
 
 namespace domain::containers {
 class terminal;
-class log_command
-  : public core::commands::command
-  , public core::operations::interactive_session_listener
+class log_command: 
+public core::commands::command,
+public core::operations::interactive_session_listener
 {
 public:
   log_command();

--- a/include/domain/images/build_command.h
+++ b/include/domain/images/build_command.h
@@ -2,37 +2,34 @@
 #define __JC_DOMAIN_IMAGES_BUILD_COMMAND__
 
 #include <core/commands/command.h>
-#include <core/sessions/staged_session_listener.h>
+#include <core/sessions/interactive_session_listener.h>
 #include <memory>
 #include <optional>
 
 namespace core::operations {
-class staged_session;
+class interactive_session;
 };
-namespace indicators {
-class ProgressBar;
-}
+
 using namespace core::operations;
 namespace domain::images {
-class build_command
-  : public core::commands::command
-  , public core::operations::staged_session_listener
+class build_command: 
+public core::commands::command,
+public core::operations::interactive_session_listener
 {
 public:
   build_command();
   void on_setup(lyra::command &cmd) override;
   void on_invockation(const lyra::group &g) override;
-  // callback listeners
-  void on_start() override;
-  void on_progress(const std::string &feed, float progress) override;
+  // interactive session callbacks
+  void on_start(bool is_remote) override;
+  void on_data_received(const std::vector<uint8_t> &data) override;
   void on_finish(bool is_failure, const std::string &message) override;
   virtual ~build_command();
 
 private:
   std::string file_path;
   std::string name;
-  std::unique_ptr<staged_session> session;
-  std::unique_ptr<indicators::ProgressBar> progress_bar;
+  std::unique_ptr<interactive_session> session;
 };
 }// namespace domain::images
 

--- a/include/domain/images/parser.h
+++ b/include/domain/images/parser.h
@@ -1,14 +1,16 @@
 #ifndef __JC_DOMAIN_IMAGES_POD_PARSER__
 #define __JC_DOMAIN_IMAGES_POD_PARSER__
 
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/split.hpp>
 #include <domain/images/payloads.h>
 #include <filesystem>
 #include <fmt/format.h>
-#include <fstream>
 #include <optional>
-#include <range/v3/range/conversion.hpp>
-#include <range/v3/view/split.hpp>
-#include <range/v3/view/transform.hpp>
+#include <fstream>
+
+
 
 namespace fs = std::filesystem;
 using namespace ranges;
@@ -49,32 +51,48 @@ inline auto add_stage(const std::string &line, description &desc, std::string &c
     current_stage_name = stage_name;
     current_stage.name = stage_name;
     std::string step = fmt::format("{}:{}", parts.at(0), image_tag);
-    current_stage.steps.try_emplace(step, step_type::from);
+    current_stage.steps.push_back({step, step_type::from});
     desc.stages.try_emplace(stage_name, current_stage);
   }
 }
 
-inline auto add_step(const std::string &line, description &desc, std::string &current_stage, step_type type) -> void
+inline auto add_step(const std::string &line, description &desc, std::string &current_stage_name, step_type type) -> void
 {
-  if (auto pos = desc.stages.find(current_stage); pos != desc.stages.end()) {
-    pos->second.steps.try_emplace(line, type);
+  if(current_stage_name.empty())
+  {
+    current_stage_name = std::string("0");
+    stage current_stage{};
+    current_stage.name = current_stage_name;
+    desc.stages.try_emplace(current_stage_name, current_stage);
+  }
+  if (auto pos = desc.stages.find(current_stage_name); pos != desc.stages.end()) {
+    pos->second.steps.push_back({line, type});
   }
 }
 
 auto parse_description(fs::path &file_path) -> std::optional<description>
 {
   std::ifstream file(file_path);
-  if (file.is_open()) { return std::nullopt; }
+  if (!file.is_open() || file.bad()) 
+  { 
+    return std::nullopt; 
+  }
   description desc{ {}, {} };
   std::string current_stage;
   std::string line;
-  while (std::getline(file, line)) {}
+  while (std::getline(file, line))
   {
     auto parts = line | views::split(' ') | to<std::vector<std::string>>();
     if (parts.size() > 0) {
       auto mark = parts.at(0);
-      line.replace(line.find_first_of(mark), 1, "");
-
+      if(step_map.find(mark) == step_map.end())
+      {
+        continue;
+      }
+      // line.replace(line.find_first_of(mark), 1, "");
+      auto elements = std::vector<std::string>(parts.begin() + 1, parts.end());
+      auto delimiter = " ";
+      line = fmt::format("{}", fmt::join(elements, delimiter));
       if (auto pos = step_map.find(mark); pos != step_map.end()) {
         add_step(line, desc, current_stage, pos->second);
       } else if (mark == "FROM") {
@@ -93,17 +111,20 @@ auto parse_description(fs::path &file_path) -> std::optional<description>
   return std::make_optional(desc);
 }
 
-build_order create_build_order(const description &desc, std::string &name, const fs::path &file_path)
+build_order create_build_order(const description &desc, const std::string &name, const fs::path &file_path)
 {
-  auto parts = name.find(":") != std::string::npos ? (name | views::split(' ') | to<std::vector<std::string>>())
+  auto parts = name.find(":") != std::string::npos ? (name | views::split(':') | to<std::vector<std::string>>())
                                                    : std::vector<std::string>{ name, "latest" };
-
+  
   build_order order{};
   order.name = parts.at(0);
   order.tag = parts.at(1);
   order.labels = desc.labels;
   order.entry_point = desc.entry_point;
-  for (auto &stage : desc.stages) { order.stages.push_back(stage.second); }
+  for (auto &[name, stage] : desc.stages) 
+  { 
+    order.stages.push_back(stage); 
+  }
   order.current_directory = file_path.generic_string();
   return order;
 }

--- a/include/domain/images/payloads.h
+++ b/include/domain/images/payloads.h
@@ -47,7 +47,7 @@ enum class step_type : int { from = 0, run = 1, work_dir = 2, copy = 3, expose =
 struct stage
 {
   std::string name;
-  std::map<std::string, step_type> steps;
+  std::vector<std::pair<std::string, step_type>> steps;
   MSGPACK_DEFINE(name, steps)
 
   bool operator==(const stage rhs) { return (this->name == rhs.name && this->steps == rhs.steps); }

--- a/src/domain/images/build_command.cc
+++ b/src/domain/images/build_command.cc
@@ -1,26 +1,18 @@
-#include <core/sessions/staged_session.h>
+#include <core/sessions/interactive_session.h>
 #include <domain/images/build_command.h>
 #include <domain/images/parser.h>
-#include <filesystem>
 #include <fmt/color.h>
-#include <indicators/cursor_control.hpp>
-#include <indicators/progress_bar.hpp>
+#include <filesystem>
+
 namespace fs = std::filesystem;
 namespace ro = core::operations::request;
-using namespace indicators;
 
 namespace domain::images {
-build_command::build_command()
-  : command("build"), file_path("."), name(""), session(nullptr),
-    progress_bar(std::make_unique<ProgressBar>(option::BarWidth{ 50 },
-      option::Start{ "[" },
-      option::Fill{ "■" },
-      option::Lead{ "■" },
-      option::Remainder{ "-" },
-      option::End{ " ]" },
-      option::PostfixText{ "Loading dependency 1/4" },
-      option::ForegroundColor{ Color::cyan },
-      option::FontStyles{ std::vector<FontStyle>{ FontStyle::bold } }))
+build_command::build_command(): 
+command("build"), 
+file_path("."), 
+name(""), 
+session(nullptr)
 {}
 void build_command::on_setup(lyra::command &cmd)
 {
@@ -29,48 +21,49 @@ void build_command::on_setup(lyra::command &cmd)
                      .name("--file")
                      .required()
                      .help("name of the description file (default: `PATH/${NAME}file`)"));
-  cmd.add_argument(
-    lyra::opt(name, "tag").name("-t").name("--tag").required().help("name and optionally a tag (format: 'name:tag')"));
+  cmd.add_argument(lyra::opt(name, "tag")
+                    .name("-t")
+                    .name("--tag")
+                    .required()
+                    .help("name and optionally a tag (format: 'name:tag')"));
 }
 void build_command::on_invockation(const lyra::group &g)
 {
-  // Hide cursor
-  show_console_cursor(false);
-  session = std::make_unique<staged_session>(*this);
+  session = std::make_unique<interactive_session>(*this);
   // now to set up the needed operational resources
   session->connect();
 }
-void build_command::on_start()
+void build_command::on_start(bool is_remote)
 {
   fs::path description_file_path(file_path);
   std::error_code error;
   if (auto path_exists = fs::exists(description_file_path, error); error || !path_exists) {
     session->disconnect();
-    show_console_cursor(true);
     fmt::print(fg(fmt::color::crimson) | fmt::emphasis::bold, "build error: {}!\n", error.message());
-  } else if (auto result = parse_description(description_file_path); result.has_value()) {
-    build_order order = create_build_order(result.value(), name, description_file_path);
+  } else if (auto result = parse_description(description_file_path); !result) {
+    session->disconnect();
+    fmt::print(fg(fmt::color::crimson) | fmt::emphasis::bold, "build error: failed to parse description file!\n");
+  } else {
+    build_order order = create_build_order(result.value(), name, description_file_path.parent_path());
     auto content = pack_build_order(order);
     session->write(ro::operation::build, ro::target::image, content);
   }
 }
-void build_command::on_progress(const std::string &feed, float progress)
-{
-  if (progress > 0 && progress <= 100) {
-    progress_bar->set_progress(progress);// all done
-  }
-  progress_bar->set_option(option::PostfixText{ feed });
+
+void build_command::on_data_received(const std::vector<uint8_t> &data) {
+    std::string entry(data.begin(), data.end());
+    fmt::print("{}", entry);
 }
+
 void build_command::on_finish(bool is_failure, const std::string &message)
 {
   session->disconnect();
-  show_console_cursor(true);
   if(is_failure)
   {
     fmt::print(fg(fmt::color::crimson) | fmt::emphasis::bold, "✘:{}!", message);
   } else 
   {
-    fmt::print(fg(fmt::color::green) | fmt::emphasis::bold, "import success: {}!\n", message);
+    fmt::print(fg(fmt::color::green) | fmt::emphasis::bold, "build success: {}!\n", message);
   }
   fmt::print(fg(fmt::color::white), "\n");
 }


### PR DESCRIPTION
- fixed `Podfile` parsing failure 
- corrected client side payload ordering of stage steps
- switched the build command to and interactive session allowing a feed of information on ongoing operations from the daemon
